### PR TITLE
(MAINT) Fix exercise numbering

### DIFF
--- a/manuscript/03-commands-and-discoverability.txt
+++ b/manuscript/03-commands-and-discoverability.txt
@@ -22,9 +22,9 @@ You wouldn't expect that a `Get-SomeObject` command would do anything but retrie
 
 T> For the rest of this workshop, you may want to keep the list of approved verbs open.
 
-{exercise, case-sensitive: false, id: get-verb}
+{exercise, case-sensitive: false, id: 01-get-verb}
 
-### Exercise 1: Get-Verb
+### Exercise 01: Get-Verb
 
 You can retrieve the available verbs (though not their meanings) from the PowerShell prompt:
 
@@ -106,9 +106,9 @@ This is the most common way we're going to use commands at the prompt, by passin
 
 With that in mind, time for an exercise!
 
-{exercise, case-sensitive: false, id: using-parameters}
+{exercise, case-sensitive: false, id: 02-using-parameters}
 
-## Exercise 2: Using Parameters
+## Exercise 02: Using Parameters
 
 ### No Parameters
 
@@ -285,9 +285,9 @@ Get-Help -Name Get-Help -Online
 
 What parameter would you add to show examples? To show the full help?
 
-{exercise, case-sensitive: false, id: getting-help}
+{exercise, case-sensitive: false, id: 03-getting-help}
 
-## Exercise 3: Getting Help
+## Exercise 03: Getting Help
 
 ### Getting Help for Get-Command
 

--- a/manuscript/04-objects-properties-methods.txt
+++ b/manuscript/04-objects-properties-methods.txt
@@ -91,9 +91,9 @@ I>
 I> Some objects will have *hidden* properties. You can use the `Force` parameter on `Select-Object` and `Get-Member` to display them.
 I> This won't *usually* be necessary.
 
-{exercise, case-sensitive: false, id: service-properties}
+{exercise, case-sensitive: false, id: 04-service-properties}
 
-## Exercise 4: Service Properties
+## Exercise 04: Service Properties
 
 Remember that you can use `Get-Service` to retrieve services; do so to retrieve the print spooler service.
 
@@ -195,9 +195,9 @@ So that gives us back some interesting information about the `Module` parameter:
 * We see that it has attributes for belonging to all parameter sets and for having an alias, both of which we would expect given the values in `ParameterSets` and `Aliases`.
 * We see that it is _not_ a switch parameter, which makes sense as it accepts input and is not a toggle.
 
-{exercise, case-sensitive: false, id: file-methods}
+{exercise, case-sensitive: false, id: 05-file-methods}
 
-## Exercise 5: File Methods
+## Exercise 05: File Methods
 
 Create a new file using the `New-Item` command.
 You can retrieve information about a file using the `Get-Item` command.
@@ -262,9 +262,9 @@ There's a few different commands you can do to change the output format:
 * `Out-Gridview` isn't strictly a formatting command, but it creates a useful popout window with the objects in it.
   In the gridview you can sort and filter through the output.
 
-{exercise, case-sensitive: false, id: formats-and-views}
+{exercise, case-sensitive: false, id: 06-formats-and-views}
 
-## Exercise 6: Formats and Views
+## Exercise 06: Formats and Views
 
 ```powershell
 Get-Command -Verb 'Format'

--- a/manuscript/05-pipeline.txt
+++ b/manuscript/05-pipeline.txt
@@ -35,9 +35,9 @@ We'll go through each step one by one:
    Note that `Out-File` does not, itself, emit any output.
    Because there is no output we cannot chain any further commands to the end of this pipeline.
 
-{exercise, case-sensitive: false, id: pipeline-chaining}
+{exercise, case-sensitive: false, id: 07-pipeline-chaining}
 
-## Exercise 7: Pipeline Chaining
+## Exercise 07: Pipeline Chaining
 
 In this exercise we're going to reverse the flow from the earlier example.
 Make sure you _actually run_ the example in your prompt before starting this exercise.

--- a/manuscript/06-filtering-and-where-object.txt
+++ b/manuscript/06-filtering-and-where-object.txt
@@ -90,8 +90,8 @@ See the table below for the list of operators and what they mean.
 "1" -is [int]
 ```
 
-{exercise, case-sensitive: false, id: equality-operators}
-## Exercise 8: Equality Operators
+{exercise, case-sensitive: false, id: 08-equality-operators}
+## Exercise 08: Equality Operators
 
 ? How would you represent five is less than 10 in PowerShell?
 
@@ -116,9 +116,9 @@ B) No
 
 {/exercise}
 
-{exercise, case-sensitive: false, id: matching-operators}
+{exercise, case-sensitive: false, id: 09-matching-operators}
 
-## Exercise 9: Matching Operators
+## Exercise 09: Matching Operators
 
 ? Which of the following strings matches the pattern "^P.ck.+": "Peter", "Piper", "Picked", "Peck", "Pickled", "Peppers"
 
@@ -147,7 +147,7 @@ D) Picked, Peck, Pickled, Peppers
 
 {/exercise}
 
-{exercise, case-sensitive: false, id: containment-operators}
+{exercise, case-sensitive: false, id: 10-containment-operators}
 
 ## Exercise 10: Containment Operators
 
@@ -226,7 +226,7 @@ In the example above you might notice some interesting things we haven't seen be
 You can use the `FilterScript` parameter _instead of_ `Property` and `Value`, the way we've used `Where-Object` up until now.
 They are _mutually exclusive_ parameters.
 
-{exercise, case-sensitive: false, id: filterscript}
+{exercise, case-sensitive: false, id: 11-filterscript}
 
 ## Exercise 11: FilterScript
 

--- a/manuscript/07-variables-and-operators.txt
+++ b/manuscript/07-variables-and-operators.txt
@@ -52,7 +52,7 @@ A>
 A> Sometimes it is easier to read and understand code that uses methods rather than the arithmetic operators.
 A> This is especially true in cases where the arithmetic operators are being used in way that might not be easy to guess.
 
-{exercise, case-sensitive: false, id: arithmetic-operators}
+{exercise, case-sensitive: false, id: 12-arithmetic-operators}
 
 ## Exercise 12: Arithmetic Operators
 

--- a/manuscript/08-providers.txt
+++ b/manuscript/08-providers.txt
@@ -43,7 +43,7 @@ The same command works across three completely different providers - it returned
 
 Similarly, the rest of the `*-Item*` commands (you can use `Get-Command` to retrieve the full list) can be used to interact with those items.
 
-{exercise, case-sensitive: false, id: files-and-folders}
+{exercise, case-sensitive: false, id: 13-files-and-folders}
 
 ## Exercise 13: Files and Folders
 
@@ -160,9 +160,9 @@ Use the command `Pop-Location`.
 
 {/exercise}
 
-{exercise, case-sensitive: false, id: registry-keys}
+{exercise, case-sensitive: false, id: 14-registry-keys}
 
-## Exercise 13: Registry Keys
+## Exercise 14: Registry Keys
 
 Run the following commands:
 
@@ -222,9 +222,9 @@ Remove-Item -Path HKCU:\pwshop -Recurse
 
 {/exercise}
 
-{exercise, case-sensitive: false, id: certificates}
+{exercise, case-sensitive: false, id: 15-certificates}
 
-## Exercise 14: Certificates
+## Exercise 15: Certificates
 
 Run the following commands:
 

--- a/manuscript/09-remoting.txt
+++ b/manuscript/09-remoting.txt
@@ -87,9 +87,9 @@ Functionally, as far as running commands is concerned, all you need is an open P
 
 There's more to discuss with remoting, such as [session configurations](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_session_configurations?view=powershell-6) and [implicit remoting](https://4sysops.com/archives/using-implicit-powershell-remoting-to-import-remote-modules/), but those topics are beyond the scope of this workshop.
 
-{exercise, case-sensitive: false, id: running-remote-commands}
+{exercise, case-sensitive: false, id: 16-running-remote-commands}
 
-### Exercise 15: Running Remote Commands
+### Exercise 16: Running Remote Commands
 
 Before answering the below questions, run this command:
 

--- a/manuscript/10-modules-and-gallery.txt
+++ b/manuscript/10-modules-and-gallery.txt
@@ -30,9 +30,9 @@ There's a set of commands for interacting both with the gallery and with PowerSh
 
 - `Get-Command -Module PowerShellGet`
 
-{exercise, case-sensitive: false, id: modules}
+{exercise, case-sensitive: false, id: 17-modules}
 
-## Exercise 16: Modules
+## Exercise 17: Modules
 
 ? What command would you use to convert text from YAML format to PowerShell?
 

--- a/manuscript/11-scripts-and-loops.txt
+++ b/manuscript/11-scripts-and-loops.txt
@@ -111,8 +111,8 @@ Case ($Pet.Category) {
 }
 ```
 
-{exercise, case-sensitive: false, id: conditionals}
-## Exercise 17: Conditionals
+{exercise, case-sensitive: false, id: 18-conditionals}
+## Exercise 18: Conditionals
 
 In the VSCode editor, open the `example.ps1` file.
 Between each step below, run the file.
@@ -296,8 +296,8 @@ I am 4
 I am 8
 ```
 
-{exercise, case-sensitive: false, id: loops}
-## Exercise 18: Loops
+{exercise, case-sensitive: false, id: 19-loops}
+## Exercise 19: Loops
 
 In the VSCode editor, open the `example.ps1` file and clear it of any existing content.
 Between each step below, run the file by running the command below in the terminal of the editor:
@@ -527,8 +527,8 @@ It will randomly determine a number and, if that random number is even, it will 
 Note that, if the terminating is _not_ thrown, `Message 3` _will_ display and the `caught` message will not.
 The first two messages and the message in the `Finally` block will _always_ display.
 
-{exercise, case-sensitive: false, id: error-handling}
-## Exercise 19: Error Handling
+{exercise, case-sensitive: false, id: 20-error-handling}
+## Exercise 20: Error Handling
 
 In the VSCode editor, open the `example.ps1` file and clear it of any existing contents, replacing it with the following:
 


### PR DESCRIPTION
This commit fixes the exercise numbering since 13 was
improperly listed twice. It also prepends the number
to the exercise ID in order to get them to display
correctly in the exercises panel.

- Reported by @corbob